### PR TITLE
Some little improvements

### DIFF
--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -188,7 +188,7 @@ import UIKit
             // needs to be unrestricted for it to correctly lay out all the text.
             // Might be due to a difference in the computed text sizes of `UILabel`
             // and `NSLayoutManager`.
-            textContainer.size = CGSize(width: CGRectGetWidth(bounds), height: CGFloat.max)
+            textContainer.size = self.textRectForBounds(self.bounds, limitedToNumberOfLines: self.numberOfLines).size
             layoutManager.ensureLayoutForTextContainer(textContainer)
             
             let glyphIndex = layoutManager.glyphIndexForPoint(point, inTextContainer: textContainer)

--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -73,9 +73,9 @@ import UIKit
     
     // MARK: Private
     
-    private var layoutManager: NSLayoutManager!
-    private var textStorage: NSTextStorage!
-    private var textContainer: NSTextContainer!
+    private var layoutManager = NSLayoutManager()
+    private var textStorage = NSTextStorage()
+    private var textContainer = NSTextContainer()
     
     private struct LinkRange {
         let URL: NSURL
@@ -90,7 +90,6 @@ import UIKit
     private func commonInit() {
         precondition(!adjustsFontSizeToFitWidth, "INDLinkLabel does not support the adjustsFontSizeToFitWidth property")
         
-        textContainer = NSTextContainer()
         textContainer.maximumNumberOfLines = numberOfLines
         textContainer.lineBreakMode = lineBreakMode
         textContainer.lineFragmentPadding = 0

--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -203,7 +203,7 @@ import UIKit
             // needs to be unrestricted for it to correctly lay out all the text.
             // Might be due to a difference in the computed text sizes of `UILabel`
             // and `NSLayoutManager`.
-            textContainer.size = self.textRectForBounds(self.bounds, limitedToNumberOfLines: self.numberOfLines).size
+            textContainer.size = CGSize(width: CGRectGetWidth(bounds), height: CGFloat.max)
             layoutManager.ensureLayoutForTextContainer(textContainer)
             let boundingRect = layoutManager.boundingRectForGlyphRange(layoutManager.glyphRangeForTextContainer(textContainer), inTextContainer: textContainer)
             


### PR DESCRIPTION
Hi Indragie,

I looked through the code and found a couple things I didn't quite understand.
1. This is more of a swift related question. Why do you access the instance variables directly and not via the accessors? What's the advantage of it?
2. Why is `adjustsFontSizeToFitWidth` not supported? 

I also found two snippets that I thought could be improved. Using `-textRectForBounds:limitedToNumberOfLines:` should improve future compatibility if they decide to add a `textInset` property as you mentioned earlier. 
