### PR TITLE
Add delegate method for one-off link customization

### DIFF
--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -143,11 +143,11 @@ import UIKit
                     return value as? NSURL
                 }
             }()
-
+            
             if let URL = URL {
                 let glyphRange = self.layoutManager.glyphRangeForCharacterRange(range, actualCharacterRange: nil)
                 ranges.append(LinkRange(URL: URL, glyphRange: glyphRange))
-
+                
                 // Remove `NSLinkAttributeName` to prevent `UILabel` from applying
                 // the default styling.
                 self.textStorage.removeAttribute(NSLinkAttributeName, range: range)

--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -143,7 +143,7 @@ import UIKit
                     return value as? NSURL
                 }
             }()
-            
+
             if let URL = URL {
                 let glyphRange = self.layoutManager.glyphRangeForCharacterRange(range, actualCharacterRange: nil)
                 ranges.append(LinkRange(URL: URL, glyphRange: glyphRange))

--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -31,6 +31,14 @@ import UIKit
     
     /// Called when a link is long pressed.
     optional func linkLabel(label: INDLinkLabel, didLongPressLinkWithURL URL: NSURL)
+
+    /**
+     Called when parsing links from attributed text.
+     The delegate may determine whether to use the text's original attributes,
+     use the proposed INDLinkLabel attributes (blue text color, and underlined),
+     or supply a completely custom set of attributes for the given link.
+    */
+    optional func linkLabel(label: INDLinkLabel, attributesForURL URL: NSURL, originalAttributes: NSDictionary, proposedAttributes: NSDictionary) -> NSDictionary
 }
 
 /// A simple UILabel subclass that allows for tapping and long pressing on links 
@@ -141,17 +149,24 @@ import UIKit
             if let URL = URL {
                 let glyphRange = self.layoutManager.glyphRangeForCharacterRange(range, actualCharacterRange: nil)
                 ranges.append(LinkRange(URL: URL, glyphRange: glyphRange))
-                
+
                 // Remove `NSLinkAttributeName` to prevent `UILabel` from applying
                 // the default styling.
-                let attributes = self.textStorage.attributesAtIndex(range.location, effectiveRange: nil)
-                if attributes[NSForegroundColorAttributeName] == nil {
-                    self.textStorage.addAttribute(NSForegroundColorAttributeName, value: DefaultLinkAttributes.Color, range: range)
-                }
-                if attributes[NSUnderlineStyleAttributeName] == nil {
-                    self.textStorage.addAttribute(NSUnderlineStyleAttributeName, value: DefaultLinkAttributes.UnderlineStyle.rawValue, range: range)
-                }
                 self.textStorage.removeAttribute(NSLinkAttributeName, range: range)
+
+                let originalAttributes = self.textStorage.attributesAtIndex(range.location, effectiveRange: nil)
+                var proposedAttributes = originalAttributes
+
+                if originalAttributes[NSForegroundColorAttributeName] == nil {
+                    proposedAttributes[NSForegroundColorAttributeName] = DefaultLinkAttributes.Color
+                }
+                if originalAttributes[NSUnderlineStyleAttributeName] == nil {
+                    proposedAttributes[NSUnderlineStyleAttributeName] = DefaultLinkAttributes.UnderlineStyle.rawValue
+                }
+
+                let acceptedAttributes = self.delegate?.linkLabel?(self, attributesForURL: URL, originalAttributes: originalAttributes, proposedAttributes: proposedAttributes)
+                    ?? proposedAttributes;
+                self.textStorage.setAttributes(acceptedAttributes, range: range)
             }
         }
         linkRanges = ranges

--- a/INDLinkLabel.swift
+++ b/INDLinkLabel.swift
@@ -32,12 +32,10 @@ import UIKit
     /// Called when a link is long pressed.
     optional func linkLabel(label: INDLinkLabel, didLongPressLinkWithURL URL: NSURL)
 
-    /**
-     Called when parsing links from attributed text.
-     The delegate may determine whether to use the text's original attributes,
-     use the proposed INDLinkLabel attributes (blue text color, and underlined),
-     or supply a completely custom set of attributes for the given link.
-    */
+    /// Called when parsing links from attributed text.
+    /// The delegate may determine whether to use the text's original attributes,
+    /// use the proposed INDLinkLabel attributes (blue text color, and underlined),
+    /// or supply a completely custom set of attributes for the given link.
     optional func linkLabel(label: INDLinkLabel, attributesForURL URL: NSURL, originalAttributes: NSDictionary, proposedAttributes: NSDictionary) -> NSDictionary
 }
 


### PR DESCRIPTION
The `INDLinkLabelDelegate` may now determine whether to use the text's original attributes, use the proposed `INDLinkLabel` attributes (a blue text color and an underline), or supply a completely custom set of attributes for the given link.

This is useful if your application requires different links to be styled differently within the same `INDLinkLabel`.
